### PR TITLE
Trust HTTP_PROXY env vars for aiohttp connections

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,7 @@ repos:
     hooks:
     -   id: check-ast
 -   repo: local
-    hooks:
-    -   id: pdoc
-        name: Generate docs
-        entry: pipenv run documentation
-        pass_filenames: false
-        types: [python]
-        language: system
-        
+    hooks: 
     -   id: import-sort
         name: Sort python imports
         entry: pipenv run import-sort

--- a/cloud_storage_utility/file_broker.py
+++ b/cloud_storage_utility/file_broker.py
@@ -68,7 +68,7 @@ class FileBroker:
         await self.session.close()
 
     async def __create_aiohttp_session(self):
-        return aiohttp.ClientSession()
+        return aiohttp.ClientSession(trust_env=True)
 
     async def open(self):
         """Open an aiohttp session"""

--- a/docs/cloud_storage_utility/file_broker.html
+++ b/docs/cloud_storage_utility/file_broker.html
@@ -147,7 +147,7 @@
         <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">session</span><span class="o">.</span><span class="n">close</span><span class="p">()</span>
 
     <span class="k">async</span> <span class="k">def</span> <span class="nf">__create_aiohttp_session</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="k">return</span> <span class="n">aiohttp</span><span class="o">.</span><span class="n">ClientSession</span><span class="p">()</span>
+        <span class="k">return</span> <span class="n">aiohttp</span><span class="o">.</span><span class="n">ClientSession</span><span class="p">(</span><span class="n">trust_env</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 
     <span class="k">async</span> <span class="k">def</span> <span class="nf">open</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;Open an aiohttp session&quot;&quot;&quot;</span>
@@ -361,7 +361,7 @@
         <span class="k">await</span> <span class="bp">self</span><span class="o">.</span><span class="n">session</span><span class="o">.</span><span class="n">close</span><span class="p">()</span>
 
     <span class="k">async</span> <span class="k">def</span> <span class="nf">__create_aiohttp_session</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="k">return</span> <span class="n">aiohttp</span><span class="o">.</span><span class="n">ClientSession</span><span class="p">()</span>
+        <span class="k">return</span> <span class="n">aiohttp</span><span class="o">.</span><span class="n">ClientSession</span><span class="p">(</span><span class="n">trust_env</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 
     <span class="k">async</span> <span class="k">def</span> <span class="nf">open</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;Open an aiohttp session&quot;&quot;&quot;</span>


### PR DESCRIPTION
## Pre-Requisites
- [x] Yes, I included and/or modified tests to cover these changes/additions

## Description of Changes
`aiohttp` doesn't respect `HTTP_PROXY` and `HTTPS_PROXY` variables by default. Some environments (corporate or otherwise) require proxy support to function, so we need to explicitly tell `aiohttp` to respect these values.

## Related Issues
<!-- Include a list and brief description of any tracked issues -->
<!-- e.g., "Fixes #123 - A bug that crashes the app" -->
<!-- NOTE: Each bugfix needs to use the "Fixes" or "Closes" and needs to be on its own line -->
